### PR TITLE
[FIX] Avoid concatenating with string with bool

### DIFF
--- a/product_listprice_list_view/models/product_template.py
+++ b/product_listprice_list_view/models/product_template.py
@@ -120,11 +120,13 @@ class ProductTemplate(models.Model):
                     self._get_overseas_location_name(prod_ids)
                 pt.stock_leadtime = str(supp_lt) + ' day(s)'
             if pt.local_stock == 'Yes':
-                if pt.overseas_stock == 'Yes':
-                    pt.stock_location += ', ' + self._get_local_location_name(
+                local_location_name = self._get_local_location_name(
                         prod_ids)
+                if pt.overseas_stock == 'Yes':
+                    if local_location_name:
+                        pt.stock_location += ', ' + local_location_name
                 else:
-                    pt.stock_location = self._get_local_location_name(prod_ids)
+                    pt.stock_location = local_location_name
                     pt.stock_leadtime = '0 day(s)'
 
     @api.multi

--- a/product_listprice_list_view/models/product_template.py
+++ b/product_listprice_list_view/models/product_template.py
@@ -120,8 +120,7 @@ class ProductTemplate(models.Model):
                     self._get_overseas_location_name(prod_ids)
                 pt.stock_leadtime = str(supp_lt) + ' day(s)'
             if pt.local_stock == 'Yes':
-                local_location_name = self._get_local_location_name(
-                        prod_ids)
+                local_location_name = self._get_local_location_name(prod_ids)
                 if pt.overseas_stock == 'Yes':
                     if local_location_name:
                         pt.stock_location += ', ' + local_location_name


### PR DESCRIPTION
When `_get_local_location_name` returns `False` and the product is `local_stock` and `oversea_stock`, prevent concatenating the `,` with `False` which will cause error
