### PR TITLE
[IMP] Changing location_name to store field

### DIFF
--- a/product_listprice_list_view/__openerp__.py
+++ b/product_listprice_list_view/__openerp__.py
@@ -4,7 +4,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 {
     'name': 'Product List Price Update List View',
-    'version': '8.0.1.6.0',
+    'version': '8.0.1.7.0',
     'author': 'Quartile Limited, eHanse',
     'website': 'https://www.quartile.co',
     'category': 'Product',
@@ -17,6 +17,7 @@
 * Adds a menu item 'Product List Price' to facilitate list price update
     """,
     'data': [
+        'data/ir_actions.xml',
         'views/product_product_views.xml',
     ],
     'installable': True,

--- a/product_listprice_list_view/data/ir_actions.xml
+++ b/product_listprice_list_view/data/ir_actions.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+<data>
+
+    <record id="initialize_location_name" model="ir.actions.server">
+        <field name="name">Initialize Location Name</field>
+        <field name="model_id" ref="product.model_product_template"/>
+        <field name="state">code</field>
+        <field name="code">self.browse(cr,uid,self.search(cr,uid,[]))._get_stock_location()</field>
+    </record>
+
+</data>
+</openerp>

--- a/product_listprice_list_view/models/__init__.py
+++ b/product_listprice_list_view/models/__init__.py
@@ -3,3 +3,5 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 from . import product_template
+from . import supplier_stock
+from . import stock_quant

--- a/product_listprice_list_view/models/product_template.py
+++ b/product_listprice_list_view/models/product_template.py
@@ -34,7 +34,8 @@ class ProductTemplate(models.Model):
 
     stock_location = fields.Char(
         string="Stock Location",
-        compute='_get_stock_location'
+        compute='_get_stock_location',
+        store=True,
     )
     stock_leadtime = fields.Char(
         string='Stock Lead Time',

--- a/product_listprice_list_view/models/stock_quant.py
+++ b/product_listprice_list_view/models/stock_quant.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017-2018 Quartile Limited
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from openerp import models, fields, api
+
+
+class StockQuant(models.Model):
+    _inherit = "stock.quant"
+
+    @api.multi
+    def write(self, vals):
+        res = super(StockQuant, self).write(vals)
+        if 'location_id' in vals or 'product_id' in vals or 'usage' in vals:
+            for sq in self:
+                sq.product_id.product_tmpl_id.sudo()._get_stock_location()
+        return res
+
+    @api.model
+    def create(self, vals):
+        res = super(StockQuant, self).create(vals)
+        if 'location_id' in vals or 'product_id' in vals or 'usage' in vals:
+            res.product_id.product_tmpl_id.sudo()._get_stock_location()
+        return res

--- a/product_listprice_list_view/models/stock_quant.py
+++ b/product_listprice_list_view/models/stock_quant.py
@@ -22,3 +22,13 @@ class StockQuant(models.Model):
         if 'location_id' in vals or 'product_id' in vals or 'usage' in vals:
             res.product_id.product_tmpl_id.sudo()._get_stock_location()
         return res
+
+    @api.multi
+    def unlink(self):
+        products = []
+        for sq in self:
+            products.append(sq.product_id.product_tmpl_id)
+        res = super(StockQuant, self).unlink()
+        for product in products:
+            product.sudo()._get_stock_location()
+        return res

--- a/product_listprice_list_view/models/supplier_stock.py
+++ b/product_listprice_list_view/models/supplier_stock.py
@@ -22,3 +22,13 @@ class SupplierStock(models.Model):
         if 'partner_loc_id' in vals or 'product_id' in vals:
             res.product_id.product_tmpl_id.sudo()._get_stock_location()
         return res
+
+    @api.multi
+    def unlink(self):
+        products = []
+        for ss in self:
+            products.append(ss.product_id.product_tmpl_id)
+        res = super(SupplierStock, self).unlink()
+        for  product in products:
+            product.sudo()._get_stock_location()
+        return res

--- a/product_listprice_list_view/models/supplier_stock.py
+++ b/product_listprice_list_view/models/supplier_stock.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017-2018 Quartile Limited
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from openerp import models, fields, api
+
+
+class SupplierStock(models.Model):
+    _inherit = "supplier.stock"
+
+    @api.multi
+    def write(self, vals):
+        res = super(SupplierStock, self).write(vals)
+        if 'partner_loc_id' in vals or 'product_id' in vals:
+            for ss in self:
+                ss.product_id.product_tmpl_id.sudo()._get_stock_location()
+        return res
+
+    @api.model
+    def create(self, vals):
+        res = super(SupplierStock, self).create(vals)
+        if 'partner_loc_id' in vals or 'product_id' in vals:
+            res.product_id.product_tmpl_id.sudo()._get_stock_location()
+        return res


### PR DESCRIPTION
- In order to search `location_name` in the view, it has to be a store field.
- Since the computation method involves different fields from different models, therefore the compute method will be run manually during creation/updating/deletion of the `supplier.stock` and `stock.quant`.
- Add a server action `initialize_location_name` to initialzie the value of the `location_name` field.