### PR TITLE
[IMP] Add material and movement to product.template

### DIFF
--- a/model_security_adjust_oaw/models/__init__.py
+++ b/model_security_adjust_oaw/models/__init__.py
@@ -2,6 +2,8 @@
 
 from . import account_fiscalyear
 from . import account_period
-from . import supplier_stock
-from . import product_product
 from . import product_category
+from . import product_product
+from . import product_template
+from . import sale_order_line
+from . import supplier_stock

--- a/model_security_adjust_oaw/models/product_product.py
+++ b/model_security_adjust_oaw/models/product_product.py
@@ -9,6 +9,7 @@ from openerp import SUPERUSER_ID
 class ProductProduct(osv.osv):
     _inherit = "product.product"
     _order = "name_template"
+
     def name_get(self, cr, user, ids, context=None):
         if context is None:
             context = {}

--- a/model_security_adjust_oaw/models/product_template.py
+++ b/model_security_adjust_oaw/models/product_template.py
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+# Copyright 2018 Quartile Limited
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from openerp import models, fields, api
+
+
+class ProductTemplate(models.Model):
+    _inherit = "product.template"
+
+    material = fields.Char(
+        string="Material",
+        compute="_get_material_and_movement"
+    )
+    movement = fields.Char(
+        string="Movement",
+        compute="_get_material_and_movement"
+    )
+
+    @api.multi
+    def _get_material_and_movement(self):
+        for pt in self:
+            description = pt.name
+            if "AC" in description:
+                pt.material = "QZ"
+            elif "5N" in description:
+                pt.material = "Rose Gold"
+            elif "OG" in description:
+                pt.material = "White Gold"
+            else:
+                pt.material = "Steel"
+            if "QZ" in description:
+                pt.movement = "Quartz"
+            else:
+                pt.movement = "Automatic"

--- a/model_security_adjust_oaw/models/sale_order_line.py
+++ b/model_security_adjust_oaw/models/sale_order_line.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+# Copyright 2018 Quartile Limited
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from openerp import models, fields, api
+
+
+class SaleOrderLine(models.Model):
+    _inherit = "sale.order.line"
+
+    material = fields.Char(
+        string="Material",
+        related="product_id.product_tmpl_id.material",
+        readonly=True,
+    )
+    movement = fields.Char(
+        string="Movement",
+        related="product_id.product_tmpl_id.movement",
+        readonly=True,
+    )

--- a/model_security_adjust_oaw/models/supplier_stock.py
+++ b/model_security_adjust_oaw/models/supplier_stock.py
@@ -40,8 +40,7 @@ class SupplierStock(models.Model):
             )
         return result
 
-        # Takes care of the product selection in Supplier Access views
-
+    # Takes care of the product selection in Supplier Access views
     @api.onchange('prod_cat_selection')
     def on_change_category(self):
         ids = []
@@ -80,7 +79,7 @@ class SupplierStock(models.Model):
     @api.multi
     def _get_owners_duplicates(self):
         for ps in self:
-            # Duplidates of the supplier accessing his entries
+            # Duplicates of the supplier accessing his entries
             owners_duplicates = self.sudo().search(
                 [('product_id', '=', ps.product_id.id),
                  ('partner_id', '=', ps.partner_id.id),
@@ -106,7 +105,6 @@ class SupplierStock(models.Model):
                 ], order='sequence')
                 for action in server_actions:
                     action.sudo()._process(action, [res.id])
-
         return res
 
     @api.model


### PR DESCRIPTION
Fixing the accident in production server that the incorrect branch is used, i.e. the view has been updated but the fields (`movement` and `material`) are missing. Therefore this PR will add these two fields to prevent internal server error.