### PR TITLE
Remove redundant field pricelist-id

### DIFF
--- a/model_security_adjust_oaw/views/sale_order_views.xml
+++ b/model_security_adjust_oaw/views/sale_order_views.xml
@@ -28,18 +28,6 @@
             </field>
         </record>
 
-          <!--Making Pricelist visible, behind Payment Term-->
-        <record id="view_order_form_fm_pricelist_visible" model="ir.ui.view">
-            <field name="name">view.order.form.tree.adjust.supplier.fm</field>
-            <field name="model">sale.order</field>
-            <field name="inherit_id" ref="sale.view_order_form"/>
-            <field name="arch" type="xml">
-                    <xpath expr="//field[@name='payment_term']" position="after">
-                        <field name="pricelist_id"/>
-                    </xpath>
-            </field>
-        </record>
-
 
         <record id="view_order_form_inherit" model="ir.ui.view">
             <field name="name">sale.order.form.sale.stock</field>


### PR DESCRIPTION
- Remove the `pricelist_id` field which is duplicated in the `sale.order` form view