### PR TITLE
[IMP] Add line sequence field to sales order

### DIFF
--- a/sale_view_adjust_oaw/__openerp__.py
+++ b/sale_view_adjust_oaw/__openerp__.py
@@ -1,13 +1,13 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017 Quartile Limted
+# Copyright 2017-2018 Quartile Limted
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 {
     'name': 'Sales View Adjust OAW',
     'summary': '',
-    'version': '8.0.1.0.1',
+    'version': '8.0.1.1.0',
     'category': 'Sales',
     'author': 'Quartile Limited',
-    'website': 'https://www.odoo-asia.com',
+    'website': 'https://www.quartile.co',
     'description': """
     """,
     "license": "AGPL-3",
@@ -22,6 +22,7 @@
         'sale_margin'
     ],
     'data': [
+        'data/ir_actions.xml',
         'views/sale_order_views.xml',
     ],
 }

--- a/sale_view_adjust_oaw/data/ir_actions.xml
+++ b/sale_view_adjust_oaw/data/ir_actions.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data>
+
+        <record id="action_run_ir_action_sequence_sale_order_line"
+                model="ir.actions.server">
+            <field name="name">Update line sequence</field>
+            <field name="condition">True</field>
+            <field name="type">ir.actions.server</field>
+            <field name="model_id" ref="sale.model_sale_order"/>
+            <field name="state">code</field>
+            <field name="code">
+orders = self.browse(cr, uid, context.get('active_ids', []), context=context)
+for order in orders:
+    order._update_order_line_sequence()
+            </field>
+        </record>
+
+    </data>
+</openerp>

--- a/sale_view_adjust_oaw/models/__init__.py
+++ b/sale_view_adjust_oaw/models/__init__.py
@@ -1,3 +1,4 @@
 # -*- coding: utf-8 -*-
 
+from . import sale_order
 from . import sale_order_line

--- a/sale_view_adjust_oaw/models/sale_order.py
+++ b/sale_view_adjust_oaw/models/sale_order.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+# Copyright 2018 Quartile Limted
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from openerp import models, fields, api
+
+
+class SaleOrder(models.Model):
+    _inherit = "sale.order"
+
+    @api.multi
+    def write(self, vals):
+        res = super(SaleOrder, self).write(vals)
+        for order in self:
+            order._update_order_line_sequence()
+        return res
+
+    @api.model
+    def create(self, vals):
+        res = super(SaleOrder, self).create(vals)
+        for order in res:
+            order._update_order_line_sequence()
+        return res
+
+    def _update_order_line_sequence(self):
+        order_lines = sorted(self.order_line, key=lambda r: (
+            r.sequence, r.id))
+        sequence = 1
+        for order_line in order_lines:
+            order_line.line_sequence = sequence
+            sequence += 1

--- a/sale_view_adjust_oaw/models/sale_order_line.py
+++ b/sale_view_adjust_oaw/models/sale_order_line.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017 Quartile Limted
+# Copyright 2017-2018 Quartile Limted
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 from openerp import models, fields
@@ -18,4 +18,7 @@ class SaleOrderLine(models.Model):
         'Image',
         related='product_id.product_tmpl_id.image_small',
         readonly=True,
+    )
+    line_sequence = fields.Integer(
+        string="Sequence",
     )

--- a/sale_view_adjust_oaw/views/sale_order_views.xml
+++ b/sale_view_adjust_oaw/views/sale_order_views.xml
@@ -2,7 +2,6 @@
 <openerp>
     <data>
 
-
         <record id="view_order_form_tree_adjust" model="ir.ui.view">
             <field name="name">view.order.form.tree.adjust</field>
             <field name="model">sale.order</field>
@@ -11,6 +10,7 @@
             <field name="arch" type="xml">
                 <xpath expr="/form/sheet/notebook/page[@string='Order Lines']/field[@name='order_line']/tree[@string='Sales Order Lines']/field[@name='product_id']"
                        position="before">
+                    <field name="line_sequence"/>
                     <field name="image_small" widget="image" height="64px"/>
                 </xpath>
                 <xpath expr="/form/sheet/notebook/page[@string='Order Lines']/field[@name='order_line']/tree[@string='Sales Order Lines']/field[@name='lot_id']"


### PR DESCRIPTION
- Add `line_sequence` to `sale.order.line`
- Update `line_sequence` when the sales order is being created/updated.
- Add a method `Update line sequence` to manually setup the `line_sequence`.