### PR TITLE
Add "Sequence" to Delivery Order and Purchase Order

### DIFF
--- a/purchase_view_adjust_oaw/__openerp__.py
+++ b/purchase_view_adjust_oaw/__openerp__.py
@@ -1,12 +1,12 @@
 # -*- coding: utf-8 -*-
-# Copyright 2016-2017 Quartile Limted
+# Copyright 2016-2018 Quartile Limted
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 {
     'name': 'Purchase View Adjust',
     'summary': "",
-    'version': "8.0.1.1.1",
+    'version': "8.0.2.0.0",
     'category': 'Purchases',
-    'website': 'https://www.odoo-asia.com',
+    'website': 'https://www.quartile.co',
     'author': 'Quartile Limited',
     'license': "AGPL-3",
     'description': """
@@ -20,6 +20,7 @@
         "sale_line_quant_extended",
     ],
     'data': [
+        'data/ir_actions.xml',
         'views/purchase_order_line_views.xml',
         'views/purchase_order_views.xml',
     ],

--- a/purchase_view_adjust_oaw/data/ir_actions.xml
+++ b/purchase_view_adjust_oaw/data/ir_actions.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data>
+
+        <record id="action_run_ir_action_sequence_purchase_order_line"
+                model="ir.actions.server">
+            <field name="name">Update line sequence</field>
+            <field name="condition">True</field>
+            <field name="type">ir.actions.server</field>
+            <field name="model_id" ref="purchase.model_purchase_order"/>
+            <field name="state">code</field>
+            <field name="code">
+orders = self.browse(cr, uid, context.get('active_ids', []), context=context)
+for order in orders:
+    order._update_order_line_sequence()
+            </field>
+        </record>
+
+    </data>
+</openerp>

--- a/purchase_view_adjust_oaw/models/__init__.py
+++ b/purchase_view_adjust_oaw/models/__init__.py
@@ -1,3 +1,4 @@
 # -*- coding: utf-8 -*-
 
+from . import purchase_order
 from . import purchase_order_line

--- a/purchase_view_adjust_oaw/models/purchase_order.py
+++ b/purchase_view_adjust_oaw/models/purchase_order.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+# Copyright 2018 Quartile Limted
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from openerp import models, fields, api
+
+
+class PurchaseOrder(models.Model):
+    _inherit = "purchase.order"
+
+    @api.multi
+    def write(self, vals):
+        res = super(PurchaseOrder, self).write(vals)
+        for order in self:
+            order._update_order_line_sequence()
+        return res
+
+    @api.model
+    def create(self, vals):
+        res = super(PurchaseOrder, self).create(vals)
+        for order in res:
+            order._update_order_line_sequence()
+        return res
+
+    def _update_order_line_sequence(self):
+        order_lines = sorted(self.order_line, key=lambda r: (
+            r.line_sequence, r.id))
+        sequence = 1
+        for order_line in order_lines:
+            order_line.line_sequence = sequence
+            sequence += 1

--- a/purchase_view_adjust_oaw/models/purchase_order_line.py
+++ b/purchase_view_adjust_oaw/models/purchase_order_line.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017 Quartile Limted
+# Copyright 2017-2018 Quartile Limted
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 from openerp import models, fields
@@ -11,5 +11,9 @@ class PurchaseOrderLine(models.Model):
     image_small = fields.Binary(
         'Image',
         related='product_id.product_tmpl_id.image_small',
+        readonly=True,
+    )
+    line_sequence = fields.Integer(
+        string="Sequence",
         readonly=True,
     )

--- a/purchase_view_adjust_oaw/views/purchase_order_views.xml
+++ b/purchase_view_adjust_oaw/views/purchase_order_views.xml
@@ -7,6 +7,9 @@
         <field name="model">purchase.order</field>
         <field name="inherit_id" ref="purchase.purchase_order_form"/>
         <field name="arch" type="xml">
+            <xpath expr="//tree/field[@name='product_id']" position="before">
+                <field name="line_sequence"/>
+            </xpath>
             <xpath expr="//tree/field[@name='product_qty']" position="before">
                 <field name="image_small" widget="image" height="64px"/>
             </xpath>

--- a/sale_view_adjust_oaw/__openerp__.py
+++ b/sale_view_adjust_oaw/__openerp__.py
@@ -4,7 +4,7 @@
 {
     'name': 'Sales View Adjust OAW',
     'summary': '',
-    'version': '8.0.1.1.0',
+    'version': '8.0.1.2.0',
     'category': 'Sales',
     'author': 'Quartile Limited',
     'website': 'https://www.quartile.co',

--- a/sale_view_adjust_oaw/static/src/css/base.css
+++ b/sale_view_adjust_oaw/static/src/css/base.css
@@ -1,0 +1,3 @@
+.extend_width {
+  min-width: min-content !important;
+}

--- a/sale_view_adjust_oaw/views/sale_order_views.xml
+++ b/sale_view_adjust_oaw/views/sale_order_views.xml
@@ -2,6 +2,24 @@
 <openerp>
     <data>
 
+        <template id="assets_backend" name="sale_view_adjust_oaw assets"
+                  inherit_id="web.assets_backend">
+            <xpath expr="." position="inside">
+                <link rel="stylesheet" href="/sale_view_adjust_oaw/static/src/css/base.css"/>
+            </xpath>
+        </template>
+
+        <record id="view_order_form" model="ir.ui.view">
+            <field name="name">view.order.form.adjust</field>
+            <field name="model">sale.order</field>
+            <field name="inherit_id" ref="sale.view_order_form"/>
+            <field name="arch" type="xml">
+                <xpath expr="//sheet" position="attributes">
+                    <attribute name="class">extend_width</attribute>
+                </xpath>
+            </field>
+        </record>
+
         <record id="view_order_form_tree_adjust" model="ir.ui.view">
             <field name="name">view.order.form.tree.adjust</field>
             <field name="model">sale.order</field>

--- a/stock_view_adjust_oaw/__openerp__.py
+++ b/stock_view_adjust_oaw/__openerp__.py
@@ -1,14 +1,14 @@
 # -*- coding: utf-8 -*-
-# Copyright 2015-2017 Quartile Limted
+# Copyright 2015-2018 Quartile Limted
 # Copyright 2017 eHanse
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 {
     'name': 'Stock View Adjust OAW',
     'summary': '',
-    'version': '8.0.1.2.0',
+    'version': '8.0.2.0.0',
     'category': 'Stock',
     'author': 'Quartile Limited',
-    'website': 'https://www.odoo-asia.com',
+    'website': 'https://www.quartile.co',
     'description': """
     """,
     "license": "AGPL-3",
@@ -21,6 +21,7 @@
         'stock_picking_menu',
     ],
     'data': [
+        'data/ir_actions.xml',
         'views/stock_move_views.xml',
         'views/stock_picking_views.xml',
         'views/stock_quant_views.xml',

--- a/stock_view_adjust_oaw/data/ir_actions.xml
+++ b/stock_view_adjust_oaw/data/ir_actions.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data>
+
+        <record id="action_run_ir_action_sequence_stock_picking"
+                model="ir.actions.server">
+            <field name="name">Update line sequence</field>
+            <field name="condition">True</field>
+            <field name="type">ir.actions.server</field>
+            <field name="model_id" ref="stock.model_stock_picking"/>
+            <field name="state">code</field>
+            <field name="code">
+pickings = self.browse(cr, uid, context.get('active_ids', []), context=context)
+for picking in pickings:
+    picking._update_move_line_sequence()
+            </field>
+        </record>
+
+    </data>
+</openerp>

--- a/stock_view_adjust_oaw/models/__init__.py
+++ b/stock_view_adjust_oaw/models/__init__.py
@@ -1,3 +1,4 @@
 # -*- coding: utf-8 -*-
 
 from . import stock_move
+from . import stock_picking

--- a/stock_view_adjust_oaw/models/stock_move.py
+++ b/stock_view_adjust_oaw/models/stock_move.py
@@ -14,3 +14,7 @@ class StockMove(models.Model):
         related='product_id.product_tmpl_id.image_small',
         readonly=True,
     )
+    line_sequence = fields.Integer(
+        string="Sequence",
+        readonly=True,
+    )

--- a/stock_view_adjust_oaw/models/stock_picking.py
+++ b/stock_view_adjust_oaw/models/stock_picking.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+# Copyright 2018 Quartile Limted
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from openerp import models, fields, api
+
+
+class StockPicking(models.Model):
+    _inherit = "stock.picking"
+
+    @api.multi
+    def write(self, vals):
+        res = super(StockPicking, self).write(vals)
+        for picking in self:
+            picking._update_move_line_sequence()
+        return res
+
+    @api.model
+    def create(self, vals):
+        res = super(StockPicking, self).create(vals)
+        for picking in res:
+            picking._update_move_line_sequence()
+        return res
+
+    def _update_move_line_sequence(self):
+        move_lines = sorted(self.move_lines, key=lambda r: (
+            r.line_sequence, r.id))
+        sequence = 1
+        for move_line in move_lines:
+            move_line.line_sequence = sequence
+            sequence += 1

--- a/stock_view_adjust_oaw/views/stock_move_views.xml
+++ b/stock_view_adjust_oaw/views/stock_move_views.xml
@@ -18,6 +18,9 @@
         <field name="model">stock.move</field>
         <field name="inherit_id" ref="stock.view_move_picking_tree"/>
         <field name="arch" type="xml">
+            <xpath expr="//field[@name='product_id']" position="before">
+                <field name="line_sequence"/>
+            </xpath>
             <xpath expr="//field[@name='product_uom_qty']" position="before">
                 <field name="image_small" widget="image" height="64px"/>
             </xpath>


### PR DESCRIPTION
- Add `line_sequence` to `purchase.order.line` and `stock.move`
- Add `bass.css` to adjust the width of the form in Sales Order