### PR TITLE
Product List Price Update View Adjustments 

### DIFF
--- a/product_listprice_list_view/models/product_template.py
+++ b/product_listprice_list_view/models/product_template.py
@@ -31,7 +31,6 @@ class ProductTemplate(models.Model):
         compute='_get_stock_cost',
         digits=dp.get_precision('Product Price'),
     )
-
     stock_location = fields.Char(
         string="Stock Location",
         compute='_get_stock_location',
@@ -41,7 +40,6 @@ class ProductTemplate(models.Model):
         string='Stock Lead Time',
         compute='_get_stock_location',
     )
-
     partner_note2 = fields.Text(
         string = 'Partner Note',
         compute='_get_stock_location',
@@ -62,10 +60,10 @@ class ProductTemplate(models.Model):
     def _get_supp_stock_cost(self, prod_ids):
         st_obj = self.env['supplier.stock']
         records = st_obj.search(
-            [('product_id', 'in', prod_ids)]
+            [('product_id', 'in', prod_ids),
+             ('quantity', '>', 0)]
         )
         if records:
-            records._compute_price_base()
             return min(r.price_unit_base for r in records)
         return False
 

--- a/product_listprice_list_view/models/product_template.py
+++ b/product_listprice_list_view/models/product_template.py
@@ -65,6 +65,7 @@ class ProductTemplate(models.Model):
             [('product_id', 'in', prod_ids)]
         )
         if records:
+            records._compute_price_base()
             return min(r.price_unit_base for r in records)
         return False
 
@@ -94,9 +95,10 @@ class ProductTemplate(models.Model):
 
     def _get_overseas_location_name(self, prod_ids):
         ss_obj = self.env['supplier.stock']
-        ss_recs = ss_obj.search(
-            [('product_id', 'in', prod_ids)]
-        )
+        ss_recs = ss_obj.sudo().search([
+            ('product_id', 'in', prod_ids),
+            ('quantity', '>', 0)
+        ])
         lowest_cost = 0.0
         lowest_cost_ss_rec = False
         for ss_rec in ss_recs:

--- a/product_listprice_list_view/models/supplier_stock.py
+++ b/product_listprice_list_view/models/supplier_stock.py
@@ -11,7 +11,8 @@ class SupplierStock(models.Model):
     @api.multi
     def write(self, vals):
         res = super(SupplierStock, self).write(vals)
-        if 'partner_loc_id' in vals or 'product_id' in vals:
+        if 'partner_loc_id' in vals or 'product_id' in vals or 'quantity' in \
+                vals:
             for ss in self:
                 ss.product_id.product_tmpl_id.sudo()._get_stock_location()
         return res
@@ -19,7 +20,8 @@ class SupplierStock(models.Model):
     @api.model
     def create(self, vals):
         res = super(SupplierStock, self).create(vals)
-        if 'partner_loc_id' in vals or 'product_id' in vals:
+        if 'partner_loc_id' in vals or 'product_id' in vals or 'quantity' in \
+                vals:
             res.product_id.product_tmpl_id.sudo()._get_stock_location()
         return res
 

--- a/product_offer/__openerp__.py
+++ b/product_offer/__openerp__.py
@@ -4,7 +4,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 {
     'name': 'Product Offer',
-    'version': '8.0.1.6.0',
+    'version': '8.0.2.0.0',
     'author': 'Quartile Limited, eHanse',
     'website': 'https://www.quartile.co',
     'category': 'Product',
@@ -18,6 +18,7 @@
     'description': """
     """,
     'data': [
+        'data/ir_actions.xml',
         'views/product_template_views.xml',
     ],
     'post_init_hook': '_update_prod_tmpl_fields',

--- a/product_offer/data/ir_actions.xml
+++ b/product_offer/data/ir_actions.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+<data>
+
+    <record id="update_overseas_info_action" model="ir.actions.server">
+        <field name="name">Update Overseas Info</field>
+        <field name="model_id" ref="product.model_product_product"/>
+        <field name="state">code</field>
+        <field name="code">self.browse(cr,uid,context.get('active_ids', []))._update_overseas_info()</field>
+    </record>
+
+    <record id="update_overseas_info" model="ir.values">
+        <field eval="'client_action_multi'" name="key2"/>
+        <field eval="'product.product'" name="model"/>
+        <field name="name">update.product.overseas.info</field>
+        <field eval="'ir.actions.server,%d'%update_overseas_info_action" name="value"/>
+    </record>
+
+</data>
+</openerp>

--- a/product_offer/models/__init__.py
+++ b/product_offer/models/__init__.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017 Rooms For (Hong Kong) Limted T/A OSCG
-# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
+from . import product_product
 from . import product_template
 from . import stock_quant
 from . import stock_move

--- a/product_offer/models/product_product.py
+++ b/product_offer/models/product_product.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+# Copyright 2018 Quartile Limited
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from openerp import models, fields, api
+
+
+class ProductProduct(models.Model):
+    _inherit = "product.product"
+
+    @api.multi
+    def _update_overseas_info(self):
+        prod_tmpls = set()
+        for pp in self:
+            prod_tmpls.add(pp.product_tmpl_id)
+        for prod_tmpl in prod_tmpls:
+            ovrs_qty = 0.0
+            for prod in prod_tmpl.product_variant_ids:
+                records = self.env['supplier.stock'].sudo().search(
+                    [('product_id', '=', prod.id)]
+                )
+                for r in records:
+                    ovrs_qty += r.quantity
+            prod_tmpl.sudo().write({
+                'qty_overseas': int(ovrs_qty)
+            })
+            prod_tmpl.sudo()._get_stock_location()

--- a/product_offer/models/product_template.py
+++ b/product_offer/models/product_template.py
@@ -22,6 +22,7 @@ class ProductTemplate(models.Model):
         readonly=True,
         help="Quantity on hand plus incoming quantity from stock moves that"
              "are 'Available' ('assigned') state.",
+        copy=False,
     )
     local_stock_not_reserved = fields.Integer(
         string="Local Stock",
@@ -32,10 +33,12 @@ class ProductTemplate(models.Model):
     qty_reserved = fields.Integer(
         string="Quantity Reserved",
         readonly=True,
+        copy=False,
     )
     qty_overseas = fields.Integer(
         string="Quantity Overseas",
         readonly=True,
+        copy=False,
     )
     last_in_date = fields.Datetime(
         string="Last Incoming Date",
@@ -113,7 +116,6 @@ class ProductTemplate(models.Model):
         digits=dp.get_precision('Product Price')
     )
 
-
     @api.multi
     def _get_net_price_cny(self):
         cny_rec = self.env['res.currency'].search([('name','=','CNY')])[0]
@@ -122,9 +124,6 @@ class ProductTemplate(models.Model):
                 pt.net_price_cny = pt.net_price * cny_rec.rate_silent
                 pt.sale_hkd_ab_cn = pt.sale_hkd_ab * cny_rec.rate_silent
                 pt.sale_hkd_ac_cn = pt.sale_hkd_ac * cny_rec.rate_silent
-
-
-
 
     @api.multi
     @api.depends('list_price', 'net_price')

--- a/supplier_stock/__openerp__.py
+++ b/supplier_stock/__openerp__.py
@@ -5,7 +5,7 @@
 {
     'name': 'Supplier Stock',
     'category': 'Stock',
-    'version': '8.0.1.5.0',
+    'version': '8.0.2.0.0',
     'author': 'Quartile Limited',
     'website': 'https://www.quartile.co',
     'depends': [
@@ -17,6 +17,7 @@
     """,
     'data': [
         'security/ir.model.access.csv',
+        'data/ir_cron.xml',
         'views/supplier_location_views.xml',
         'views/supplier_stock_views.xml',
     ],

--- a/supplier_stock/data/ir_cron.xml
+++ b/supplier_stock/data/ir_cron.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data noupdate="1">
+        <record model="ir.cron" id="supplier_stock_update_base_cost">
+            <field name="name">Supplier Stock Update HKD Value Cron</field>
+            <field name="interval_number">1</field>
+            <field name="interval_type">days</field>
+            <field name="numbercall">-1</field>
+            <field name="model">supplier.stock</field>
+            <field name="function">update_price_unit_base</field>
+        </record>
+    </data>
+</openerp>

--- a/supplier_stock/models/supplier_stock.py
+++ b/supplier_stock/models/supplier_stock.py
@@ -154,3 +154,9 @@ class SupplierStock(models.Model):
             else:
                 rec.discount_in_curr = (1-(rec.price_unit/rec.retail_in_currency)) * 100
         return
+
+    @api.model
+    def update_price_unit_base(self):
+        supplier_stock = self.search([])
+        supplier_stock._compute_price_base()
+        return True


### PR DESCRIPTION
- Prevent `Qty Overseas` and `HK Stock` from being duplicated
- Add method to update `Qty Overseas` and `HK Stock` manually to handle old incorrect product
- The` Stock Location`, `Supplier Lead Time` and `Partner Note` in the view will not show Partner Stocks entry that has 0 Quantity.
- Add cron to update the HKD Value of Partner Stock everyday.