### PR TITLE
[IMP] Allow supplier user to generate the profit loss report

### DIFF
--- a/model_security_adjust_oaw/__openerp__.py
+++ b/model_security_adjust_oaw/__openerp__.py
@@ -4,7 +4,7 @@
 {
     'name': 'Model Security Adjust OAW',
     'category': 'Security',
-    'version': '8.0.2.0.0',
+    'version': '8.0.2.1.0',
     'author': 'Quartile Limited',
     'website': 'https://www.quartile.co',
     'depends': [
@@ -15,6 +15,7 @@
         'product',
         'stock_view_adjust_oaw',
         'sale_line_quant_extended',
+        'profit_loss_report',
     ],
     'summary':"""""",
     'description': """

--- a/model_security_adjust_oaw/views/reporting_views.xml
+++ b/model_security_adjust_oaw/views/reporting_views.xml
@@ -5,7 +5,19 @@
         <!--Reporting-->
         <record id="base.menu_reporting" model="ir.ui.menu">
             <field name="groups_id"
-                   eval="[(6,0, [ref('model_security_adjust_oaw.group_supplier'),ref('account.group_account_manager')])]"/>
+                   eval="[(6,0, [ref('model_security_adjust_oaw.group_supplier_fm'),ref('account.group_account_manager')])]"/>
+        </record>
+
+        <!--Reporting/Sales-->
+        <record id="base.next_id_64" model="ir.ui.menu">
+            <field name="groups_id"
+                   eval="[(6,0, [ref('model_security_adjust_oaw.group_supplier_fm'),ref('base.group_sale_manager')])]"/>
+        </record>
+
+        <!--Reporting/Sales/Sales Analysis-->
+        <record id="sale.menu_report_product_all" model="ir.ui.menu">
+            <field name="groups_id"
+                   eval="[(6,0, [ref('base.group_sale_manager')])]"/>
         </record>
 
     </data>

--- a/model_security_adjust_oaw/wizards/__init__.py
+++ b/model_security_adjust_oaw/wizards/__init__.py
@@ -2,3 +2,4 @@
 
 from . import partner_statement_report_wizard
 from . import consignment_report_wizard
+from . import profit_loss_report_wizard

--- a/model_security_adjust_oaw/wizards/profit_loss_report_wizard.py
+++ b/model_security_adjust_oaw/wizards/profit_loss_report_wizard.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+# Copyright 2018 Quartile Limited
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from openerp import models, fields, api
+
+
+class ProfitLossReportWizard(models.TransientModel):
+    _inherit = "profit.loss.report.wizard"
+
+    @api.multi
+    def action_generate_profit_loss_records(self):
+        self.ensure_one()
+        if self.env.user.has_group('model_security_adjust_oaw.group_supplier_fm'):
+            self.env.cr.execute("DELETE FROM profit_loss_report")
+            self._inject_out_invoice_data(self.from_date, self.to_date)
+            self.env.cr.execute("DELETE FROM profit_loss_report WHERE "
+                                "partner_id IS NULL or partner_id NOT IN ("
+                                "   SELECT id FROM res_partner WHERE "
+                                "   related_partner = %d)" %
+                                self.env.user.partner_id.id)
+            self._update_records()
+            self.env.cr.execute("UPDATE profit_loss_report SET "
+                                "state = NULL,"
+                                "supplier_id = NULL,"
+                                "supplier_ref = NULL,"
+                                "supplier_invoice_number = NULL,"
+                                "supplier_payment_ref = NULL,"
+                                "supplier_payment_dates = NULL,"
+                                "purchase_currency_id = NULL,"
+                                "purchase_currency_price = NULL,"
+                                "exchange_rate = NULL,"
+                                "purchase_base_price = NULL,"
+                                "purchase_order_id = NULL,"
+                                "purchase_invoice_id = NULL,"
+                                "supplier_payment_state = NULL,"
+                                "base_profit = NULL,"
+                                "base_profit_percent = NULL")
+            res = self.env.ref('profit_loss_report.profit_loss_report_action')
+            return res.read()[0]
+        return super(ProfitLossReportWizard,
+                     self).action_generate_profit_loss_records()


### PR DESCRIPTION
- Adjust the Report/Sales menu and submenus' `group_id`
- Override the `action_generate_profit_loss_records` so that the following records/fields will be deleted when the report is generated by a supplier user.
    - Records that the `Customer` is not related to the supplier user, e.g. the `related_partner` of the customer is not the supplier user.
    - All fields related to purchase
    - Profit fields and State Fields