### PR TITLE
[IMP] Change implementation of stock moves' visibility

### DIFF
--- a/model_security_adjust_oaw/__openerp__.py
+++ b/model_security_adjust_oaw/__openerp__.py
@@ -30,6 +30,8 @@
         'views/res_partner_views.xml',
         'views/sale_order_views.xml',
         'views/sale_views.xml',
+        'views/stock_config_settings_views.xml',
+        'views/stock_move_views.xml',
         'views/stock_picking_views.xml',
         'views/stock_quant_views.xml',
         'views/stock_views.xml',

--- a/model_security_adjust_oaw/models/__init__.py
+++ b/model_security_adjust_oaw/models/__init__.py
@@ -9,5 +9,6 @@ from . import product_template
 from . import res_partner
 from . import sale_order
 from . import sale_order_line
+from . import stock_config_settings
 from . import stock_move
 from . import supplier_stock

--- a/model_security_adjust_oaw/models/stock_config_settings.py
+++ b/model_security_adjust_oaw/models/stock_config_settings.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+# Copyright 2018 Quartile Limited
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from openerp import models, fields, api
+
+
+class StockConfigSettings(models.TransientModel):
+    _inherit = 'stock.config.settings'
+
+    default_supplier_pick_partner = fields.Char(
+        'Default Pick Partner For Supplier',
+    )
+
+    @api.model
+    def get_default_supplier_pick_partner(self, fields):
+        param = self.env['ir.config_parameter']
+        return {
+            'default_supplier_pick_partner': param.get_param(
+                'default_supplier_pick_partner'),
+        }
+
+    @api.multi
+    def set_default_supplier_pick_partner(self):
+        for config in self:
+            param = self.env['ir.config_parameter']
+            param.set_param('default_supplier_pick_partner',
+                            config.default_supplier_pick_partner or '')

--- a/model_security_adjust_oaw/views/stock_config_settings_views.xml
+++ b/model_security_adjust_oaw/views/stock_config_settings_views.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data>
+
+        <record id="view_stock_config_settings" model="ir.ui.view">
+            <field name="name">stock settings</field>
+            <field name="model">stock.config.settings</field>
+            <field name="inherit_id" ref="stock.view_stock_config_settings"/>
+            <field name="arch" type="xml">
+                <xpath expr="//form" position="inside">
+                    <separator name="stock_move_visibility"
+                               string="Stock Move Visibility"/>
+                    <group name="stock_move_visibility">
+                        <label for="default_supplier_pick_partner"/>
+                        <div>
+                            <field name="default_supplier_pick_partner" class="oe_inline"/>
+                        </div>
+                    </group>
+                </xpath>
+            </field>
+        </record>
+
+    </data>
+</openerp>

--- a/model_security_adjust_oaw/views/stock_move_views.xml
+++ b/model_security_adjust_oaw/views/stock_move_views.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data>
+
+        <record id="view_move_tree_extended" model="ir.ui.view">
+            <field name="name">stock.move.ext.description.adjust</field>
+            <field name="model">stock.move</field>
+            <field name="groups_id" eval="[(6, 0, [ref('group_supplier')])]"/>
+            <field name="inherit_id"
+                   ref="stock_view_adjust_oaw.view_move_tree_extended"/>
+            <field name="arch" type="xml">
+                <xpath expr="//field[@name='picking_id']"
+                       position="attributes">
+                    <attribute name="options">{'no_open': True}</attribute>
+                </xpath>
+                <xpath expr="//field[@name='so_id']"
+                       position="attributes">
+                    <attribute name="options">{'no_open': True}</attribute>
+                </xpath>
+                <xpath expr="//field[@name='po_id']"
+                       position="attributes">
+                    <attribute name="options">{'no_open': True}</attribute>
+                </xpath>
+                <xpath expr="//field[@name='group_id']"
+                       position="attributes">
+                    <attribute name="options">{'no_open': True}</attribute>
+                </xpath>
+                <xpath expr="//field[@name='pick_partner_id']"
+                       position="attributes">
+                    <attribute name="groups">stock.group_stock_manager</attribute>
+                </xpath>
+                <xpath expr="//field[@name='pick_partner_id']"
+                       position="after">
+                    <field name="supplier_pick_partner" readonly="1"
+                           groups="model_security_adjust_oaw.group_supplier"/>
+                </xpath>
+                <xpath expr="//field[@name='product_id']"
+                       position="attributes">
+                    <attribute name="options">{'no_open': True}</attribute>
+                </xpath>
+                <xpath expr="//field[@name='quant_lot_id']"
+                       position="attributes">
+                    <attribute name="options">{'no_open': True}</attribute>
+                </xpath>
+                <xpath expr="//field[@name='location_id']"
+                       position="attributes">
+                    <attribute name="options">{'no_open': True}</attribute>
+                </xpath>
+                <xpath expr="//field[@name='location_dest_id']"
+                       position="attributes">
+                    <attribute name="options">{'no_open': True}</attribute>
+                </xpath>
+            </field>
+        </record>
+
+        <record id="view_move_search_z1" model="ir.ui.view">
+            <field name="name">stock.move.ext.description.adjust</field>
+            <field name="model">stock.move</field>
+            <field name="groups_id" eval="[(6, 0, [ref('group_supplier')])]"/>
+            <field name="inherit_id"
+                   ref="stock_view_adjust_oaw.view_move_search_z1"/>
+            <field name="arch" type="xml">
+                <xpath expr="//field[@name='partner_id']"
+                       position="attributes">
+                    <attribute name="groups">stock.group_stock_manager</attribute>
+                </xpath>
+                <xpath expr="//filter[@name='by_pick_partner']"
+                       position="attributes">
+                    <attribute name="groups">stock.group_stock_manager</attribute>
+                </xpath>
+            </field>
+        </record>
+
+    </data>
+</openerp>

--- a/model_security_adjust_oaw/views/stock_views.xml
+++ b/model_security_adjust_oaw/views/stock_views.xml
@@ -11,10 +11,7 @@
             <field name="search_view_id"
                    ref="stock_view_adjust_oaw.view_move_search_z1"/>
             <field name="domain">
-                ['&amp;', ('quant_owner_related_user_id', '=', uid),
-                '|', ('so_id', '=', False),
-                '&amp;', ('so_id', '!=', False),
-                ('pick_partner_related_user_id', '=', uid)]
+                [('quant_owner_related_user_id', '=', uid)]
             </field>
         </record>
 


### PR DESCRIPTION
- Revert the domain of `stock.move` action
- Remove `pick_partner_related_user_id ` field and replace it with `supplier_pick_partner` to show the information of the partner
- Add `stock.config.settings` to define the name to be shown when the user logged in is no the related partner of the `Pick Partner` of `stock.move`
- Disable all links in the stock moves list view from supplier users
- Remove `Pick Partner` filters in the list view from supplier users