### PR TITLE
[FIX] Add groups_id to chatter box views

### DIFF
--- a/supplier_chatter_box/views/product_template_views.xml
+++ b/supplier_chatter_box/views/product_template_views.xml
@@ -6,6 +6,7 @@
             <field name="name">product.template.common.form</field>
             <field name="model">product.template</field>
             <field name="inherit_id" ref="product.product_template_form_view"/>
+            <field name="groups_id" eval="[(6,0,[ref('model_security_adjust_oaw.group_supplier')])]"/>
             <field name="arch" type="xml">
                 <xpath expr="//div[@class='oe_chatter']"
                        position="attributes">
@@ -13,8 +14,7 @@
                 </xpath>
                 <xpath expr="//div[@class='oe_chatter']"
                        position="after">
-                    <div class="oe_chatter supplier_access"
-                         groups="model_security_adjust_oaw.group_supplier">
+                    <div class="oe_chatter supplier_access">
                         <field name="message_ids" widget="mail_thread"/>
                     </div>
                 </xpath>

--- a/supplier_chatter_box/views/res_partner_views.xml
+++ b/supplier_chatter_box/views/res_partner_views.xml
@@ -6,6 +6,8 @@
             <field name="name">res.partner.form</field>
             <field name="model">res.partner</field>
             <field name="inherit_id" ref="base.view_partner_form"/>
+            <field name="groups_id"
+                   eval="[(6,0,[ref('model_security_adjust_oaw.group_supplier')])]"/>
             <field name="arch" type="xml">
                 <xpath expr="//div[@class='oe_chatter']"
                        position="attributes">
@@ -13,8 +15,7 @@
                 </xpath>
                 <xpath expr="//div[@class='oe_chatter']"
                        position="after">
-                    <div class="oe_chatter supplier_access"
-                         groups="model_security_adjust_oaw.group_supplier">
+                    <div class="oe_chatter supplier_access">
                         <field name="message_ids" widget="mail_thread"/>
                     </div>
                 </xpath>

--- a/supplier_chatter_box/views/sale_order_views.xml
+++ b/supplier_chatter_box/views/sale_order_views.xml
@@ -6,6 +6,7 @@
             <field name="name">sale.order.form</field>
             <field name="model">sale.order</field>
             <field name="inherit_id" ref="sale.view_order_form"/>
+            <field name="groups_id" eval="[(6,0,[ref('model_security_adjust_oaw.group_supplier')])]"/>
             <field name="arch" type="xml">
                 <xpath expr="//div[@class='oe_chatter']"
                        position="attributes">
@@ -13,8 +14,7 @@
                 </xpath>
                 <xpath expr="//div[@class='oe_chatter']"
                        position="after">
-                    <div class="oe_chatter supplier_access"
-                         groups="model_security_adjust_oaw.group_supplier">
+                    <div class="oe_chatter supplier_access">
                         <field name="message_ids" widget="mail_thread"/>
                     </div>
                 </xpath>


### PR DESCRIPTION
- Add `groups_id` to the view so that the views will not be loaded for internal user.
