### PR TITLE
[IMP] Supplier Invoice Number and Case Number filter adjustments

### DIFF
--- a/model_security_adjust_oaw/security/base_security.xml
+++ b/model_security_adjust_oaw/security/base_security.xml
@@ -62,6 +62,7 @@
             <field name="perm_unlink" eval="False"/>
             <field name="perm_write" eval="False"/>
         </record>
+
         <!--Narrow down quotation accessible to those created by the supplier_fm-->
         <record model="ir.rule" id="res_partner_supplier_fm_sale_rule">
             <field name="name">sale_order: stock supplier_fm: Access on own quotation; but no delete(no unlink)</field>
@@ -72,6 +73,18 @@
             <field name="perm_read" eval="True"/>
             <field name="perm_create" eval="True"/>
             <field name="perm_unlink" eval="False"/>
+            <field name="perm_write" eval="True"/>
+        </record>
+
+        <record model="ir.rule" id="stock_production_lot_supplier_rule">
+            <field name="name">stock_production_lot: supplier_fm: Access on his products' case number</field>
+            <field name="model_id"
+                   ref="stock.model_stock_production_lot"/>
+            <field name="domain_force">[('product_id.categ_id','in',user.product_category_ids.ids)]</field>
+            <field name="groups" eval="[(4, ref('group_supplier'))]"/>
+            <field name="perm_read" eval="True"/>
+            <field name="perm_create" eval="True"/>
+            <field name="perm_unlink" eval="True"/>
             <field name="perm_write" eval="True"/>
         </record>
 

--- a/model_security_adjust_oaw/security/base_security.xml
+++ b/model_security_adjust_oaw/security/base_security.xml
@@ -77,7 +77,7 @@
         </record>
 
         <record model="ir.rule" id="stock_production_lot_supplier_rule">
-            <field name="name">stock_production_lot: supplier_fm: Access on his products' case number</field>
+            <field name="name">stock_production_lot: supplier: Access on his products' case number</field>
             <field name="model_id"
                    ref="stock.model_stock_production_lot"/>
             <field name="domain_force">[('product_id.categ_id','in',user.product_category_ids.ids)]</field>

--- a/profit_loss_report/wizards/profit_loss_report_wizard.py
+++ b/profit_loss_report/wizards/profit_loss_report_wizard.py
@@ -618,15 +618,19 @@ class ProfitLossReportWizard(models.TransientModel):
         for filter in report_filters:
             if self[filter]:
                 if type(self[filter]) in (str, unicode):
-                    value = "'" + "','".join([number.strip() for number in self[
-                            filter].split(',')]) + "'"
+                    value = self[filter].strip()
+                    filters.append("(%s NOT LIKE '%%%s%%' OR %s IS NULL)" % (
+                        filter,
+                        value,
+                        filter
+                    ))
                 else:
                     value = ",".join([str(id) for id in self[filter].ids])
-                filters.append("(%s NOT IN (%s) OR %s IS NULL)" % (
-                    filter,
-                    value,
-                    filter
-                ))
+                    filters.append("(%s NOT IN (%s) OR %s IS NULL)" % (
+                        filter,
+                        value,
+                        filter
+                    ))
         if filters:
             filter_sql = "DELETE FROM profit_loss_report WHERE %s" % (
                 " OR ".join(filters)

--- a/profit_loss_report/wizards/profit_loss_report_wizard.py
+++ b/profit_loss_report/wizards/profit_loss_report_wizard.py
@@ -649,3 +649,18 @@ class ProfitLossReportWizard(models.TransientModel):
         self._update_records()
         res = self.env.ref('profit_loss_report.profit_loss_report_action')
         return res.read()[0]
+
+    @api.onchange('product_id')
+    def onchange_product_id(self):
+        ids = []
+        for product in self.product_id:
+            # Update case number domain filter
+            lot_ids = self.env['stock.production.lot'].search([
+                ('product_id', '=', product.id)
+            ])
+            ids += lot_ids.ids
+        return {
+            'domain': {'lot_id': [('id', 'in', ids)]}
+        } if ids else {
+            'domain': {'lot_id': []}
+        }


### PR DESCRIPTION
- Adjust the logic of `Supplier Invoice Number` filter so that the similar string will be picked instead of matching the exact string
- Add record rules for `stock.production.lot` that the search only shows `Case Number` that is related to the supplier.