### PR TITLE
[FIX] Filter the records after updating to consider the VCI case

### DIFF
--- a/model_security_adjust_oaw/wizards/profit_loss_report_wizard.py
+++ b/model_security_adjust_oaw/wizards/profit_loss_report_wizard.py
@@ -19,8 +19,8 @@ class ProfitLossReportWizard(models.TransientModel):
                                 "   SELECT id FROM res_partner WHERE "
                                 "   related_partner = %d)" %
                                 self.env.user.partner_id.id)
-            self._filter_records()
             self._update_records()
+            self._filter_records()
             self.env.cr.execute("UPDATE profit_loss_report SET "
                                 "state = NULL,"
                                 "supplier_id = NULL,"

--- a/profit_loss_report/wizards/profit_loss_report_wizard.py
+++ b/profit_loss_report/wizards/profit_loss_report_wizard.py
@@ -645,8 +645,8 @@ class ProfitLossReportWizard(models.TransientModel):
         from_date = self._get_utc_date(self.from_date)
         to_date = self._get_utc_date(self.to_date)
         self._inject_purchase_data(from_date, to_date)
-        self._filter_records()
         self._update_records()
+        self._filter_records()
         res = self.env.ref('profit_loss_report.profit_loss_report_action')
         return res.read()[0]
 


### PR DESCRIPTION
- Since the `supplier_id` for VCI case is assigned in the `_update_records()`, therefore the `_filter_records()` has to execute after it.