### PR TITLE
[IMP] Make filter case-insensitive, improve performance

### DIFF
--- a/model_security_adjust_oaw/wizards/profit_loss_report_wizard.py
+++ b/model_security_adjust_oaw/wizards/profit_loss_report_wizard.py
@@ -19,8 +19,9 @@ class ProfitLossReportWizard(models.TransientModel):
                                 "   SELECT id FROM res_partner WHERE "
                                 "   related_partner = %d)" %
                                 self.env.user.partner_id.id)
-            self._update_records()
+            self._update_supplier_info()
             self._filter_records()
+            self._update_records()
             self.env.cr.execute("UPDATE profit_loss_report SET "
                                 "state = NULL,"
                                 "supplier_id = NULL,"


### PR DESCRIPTION
- Extract the logic of setting the `supplier_id` from `_update_records()` to a new method. Hence the filter method will be able to execute before the `_update_records` which will improve the performance.
- Make the filter of Supplier Invoice Number case-insensitive.