### PR TITLE
[FIX] Adjust assign logic and update "Recheck Availability" button

### DIFF
--- a/stock_picking_vci_purchase_order_confirm/__openerp__.py
+++ b/stock_picking_vci_purchase_order_confirm/__openerp__.py
@@ -17,6 +17,7 @@
         'sale_line_quant_extended'
     ],
     'data': [
+        'views/stock_picking_views.xml'
     ],
     'installable': True,
     'auto_install': False,

--- a/stock_picking_vci_purchase_order_confirm/models/stock_move.py
+++ b/stock_picking_vci_purchase_order_confirm/models/stock_move.py
@@ -11,6 +11,6 @@ class StockMove(models.Model):
     @api.multi
     def action_assign(self):
         for move in self:
-            if move.picking_id.sale_id:
+            if move.picking_id.sale_id and self.env.context.get('button_assign'):
                 move.picking_id.sale_id.confirm_vci_purhcase_order()
         return super(StockMove, self).action_assign()

--- a/stock_picking_vci_purchase_order_confirm/models/stock_picking.py
+++ b/stock_picking_vci_purchase_order_confirm/models/stock_picking.py
@@ -11,7 +11,7 @@ class StockPicking(models.Model):
     @api.multi
     def action_assign(self):
         for picking in self:
-            if picking.sale_id:
+            if picking.sale_id and self.env.context.get('button_assign'):
                 picking.sale_id.confirm_vci_purhcase_order()
         return super(StockPicking, self).action_assign()
 

--- a/stock_picking_vci_purchase_order_confirm/views/stock_picking_views.xml
+++ b/stock_picking_vci_purchase_order_confirm/views/stock_picking_views.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data>
+
+        <record id="view_picking_form" model="ir.ui.view">
+            <field name="name">stock.picking.form</field>
+            <field name="model">stock.picking</field>
+            <field name="inherit_id" ref="stock.view_picking_form"/>
+            <field name="arch" type="xml">
+                <xpath expr="//button[@name='action_assign']" position="attributes">
+                    <attribute name="context">{'button_assign': 1}</attribute>
+                </xpath>
+                <xpath expr="//button[@name='rereserve_pick']"
+                       position="replace">
+                    <button name="rereserve_pick"
+                            string="Recheck Availability" type="object"
+                            class="oe_highlight" groups="base.group_user"
+                            attrs="{'invisible': ['|', ('state', 'not in', ('waiting', 'partially_available')), ('pack_operation_exist','=',True)]}"
+                            context="{'button_assign': 1}"/>
+                </xpath>
+            </field>
+        </record>
+
+  </data>
+</openerp>


### PR DESCRIPTION
- Show `Recheck Availability` button when the delivery order is waiting another operation.
- Only confirm other RFQ when the button is clicked.