### PR TITLE
[FIX] Remove support by Odoo

### DIFF
--- a/website_sale_adj/views/templates.xml
+++ b/website_sale_adj/views/templates.xml
@@ -114,5 +114,9 @@
             </xpath>
         </template>
 
+        <template id="layout_footer_copyright" inherit_id="website.layout_footer_copyright">
+            <xpath expr="//div[@class='pull-right']" position="replace"/>
+        </template>
+
     </data>
 </openerp>


### PR DESCRIPTION
- Remove "Powered by Odoo, the #1 Open Source eCommerce." in the website footer