### PR TITLE
[IMP] Add product_all_category_ids to store all child categories

### DIFF
--- a/model_security_adjust_oaw/security/base_security.xml
+++ b/model_security_adjust_oaw/security/base_security.xml
@@ -41,7 +41,7 @@
         <record model="ir.rule" id="stock_quant_supplier_rule">
             <field name="name">quants: stock supplier: Access on his products and quants</field>
             <field name="model_id" ref="stock.model_stock_quant"/>
-            <field name="domain_force">[('product_id.categ_id','in',user.product_category_ids.ids),'|',('usage','=','internal'),('owner_id','=',user.partner_id.id)]
+            <field name="domain_force">[('product_id.categ_id','in',user.product_all_category_ids.ids),'|',('usage','=','internal'),('owner_id','=',user.partner_id.id)]
             </field>
             <field name="groups" eval="[(4, ref('group_supplier_fm'))]"/>
             <field name="perm_read" eval="True"/>
@@ -55,7 +55,7 @@
             <field name="name">product_template: stock supplier_fm: Sees on certain categories</field>
             <field name="model_id"
                    ref="product.model_product_template"/>
-            <field name="domain_force">[('categ_id', 'in', user.product_category_ids.ids)]</field>
+            <field name="domain_force">[('categ_id', 'in', user.product_all_category_ids.ids)]</field>
             <field name="groups" eval="[(4, ref('group_supplier_fm'))]"/>
             <field name="perm_read" eval="True"/>
             <field name="perm_create" eval="False"/>
@@ -92,7 +92,7 @@
             <field name="name">stock_production_lot: supplier: Access on his products' case number</field>
             <field name="model_id"
                    ref="stock.model_stock_production_lot"/>
-            <field name="domain_force">[('product_id.categ_id','in',user.product_category_ids.ids)]</field>
+            <field name="domain_force">[('product_id.categ_id','in',user.product_all_category_ids.ids)]</field>
             <field name="groups" eval="[(4, ref('group_supplier'))]"/>
             <field name="perm_read" eval="True"/>
             <field name="perm_create" eval="True"/>


### PR DESCRIPTION
- By selecting the parent category, all the child categories should be visible to the user as well.
