### PR TITLE
[FIX] Adjust the record rule of sales order for supplier

### DIFF
--- a/model_security_adjust_oaw/security/base_security.xml
+++ b/model_security_adjust_oaw/security/base_security.xml
@@ -68,7 +68,7 @@
             <field name="name">sale_order: stock supplier: Access on own quotation; but no delete(no unlink)</field>
             <field name="model_id"
                    ref="sale.model_sale_order"/>
-            <field name="domain_force">[('user_id','!=',False)]</field>
+            <field name="domain_force">[('create_partner_id', 'child_of', user.commercial_partner_id.id)]</field>
             <field name="groups" eval="[(4, ref('group_supplier'))]"/>
             <field name="perm_read" eval="True"/>
             <field name="perm_create" eval="True"/>

--- a/model_security_adjust_oaw/views/sale_order_views.xml
+++ b/model_security_adjust_oaw/views/sale_order_views.xml
@@ -77,6 +77,9 @@
                        position="attributes">
                     <attribute name="groups">base.group_sale_manager</attribute>
                 </xpath>
+                <xpath expr="//field[@name='date_order']" position="after">
+                    <field name="create_partner_id"/>
+                </xpath>
             </field>
         </record>
 


### PR DESCRIPTION
Add `create_partner_id` to determine the domain of the sales order records that the supplier can see.
The field will be set as the aurthor of the sales order record by default. Sales Manager will be able to change this field and set to certain supplier that the record will be visible to the related suppliers (including the contacts)