### PR TITLE
[T907][IMP] Homepage, brand search and template adjustments 

### DIFF
--- a/website_timecheck/__manifest__.py
+++ b/website_timecheck/__manifest__.py
@@ -1,10 +1,10 @@
 # Copyright 2020 Quartile Limited
-# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
 {
     "name": "Website Timecheck Function",
     "category": "Website",
-    "version": "12.0.1.0.0",
-    "license": "AGPL-3",
+    "version": "12.0.1.2.0",
+    "license": "LGPL-3",
     "author": "Quartile Limited",
     "website": "https://www.quartile.co",
     "depends": [
@@ -19,6 +19,7 @@
         "security/timecheck_security.xml",
         "security/website_sale_security.xml",
         "views/product_product_views.xml",
+        "views/res_config_settings_views.xml",
         "views/res_users_views.xml",
         "views/sale_order_views.xml",
         "views/templates.xml",

--- a/website_timecheck/controllers/main.py
+++ b/website_timecheck/controllers/main.py
@@ -1,5 +1,5 @@
 # Copyright 2020 Quartile Limited
-# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
 
 from odoo import http
 from odoo.addons.website.controllers.main import Website
@@ -216,6 +216,7 @@ class WebsiteSale(WebsiteSale):
                     ("description", "ilike", srch),
                     ("description_sale", "ilike", srch),
                     ("product_variant_ids.default_code", "ilike", srch),
+                    ("public_categ_ids.name", "ilike", srch),
                 ]
             # Add '|' to the operator_list, as the search conditions will be
             # joined with OR but not AND
@@ -251,8 +252,9 @@ class WebsiteSale(WebsiteSale):
 class Website(Website):
     @http.route("/", type="http", auth="public", website=True)
     def index(self, **kw):
-        # << QTL Set the homepage as the shop page
-        return request.redirect("/shop")
+        # << QTL Set the homepage according to the settings
+        url = request.website.homepage_url or "/shop"
+        return request.redirect(url)
         # homepage = request.website.homepage_id
         # if homepage and (homepage.sudo().is_visible or request.env.user.has_group('base.group_user')) and homepage.url != '/': # noqa
         #     return request.env['ir.http'].reroute(homepage.url)

--- a/website_timecheck/controllers/main.py
+++ b/website_timecheck/controllers/main.py
@@ -253,7 +253,7 @@ class Website(Website):
     @http.route("/", type="http", auth="public", website=True)
     def index(self, **kw):
         # << QTL Set the homepage according to the settings
-        url = request.website.homepage_url or "/shop"
+        url = request.website.homepage_url or "/"
         return request.redirect(url)
         # homepage = request.website.homepage_id
         # if homepage and (homepage.sudo().is_visible or request.env.user.has_group('base.group_user')) and homepage.url != '/': # noqa

--- a/website_timecheck/models/__init__.py
+++ b/website_timecheck/models/__init__.py
@@ -1,4 +1,5 @@
 from . import product_template
+from . import res_config_settings
 from . import res_users
 from . import sale_order
 from . import website

--- a/website_timecheck/models/product_template.py
+++ b/website_timecheck/models/product_template.py
@@ -1,5 +1,5 @@
 # Copyright 2020 Quartile Limited
-# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
 
 import datetime
 

--- a/website_timecheck/models/res_config_settings.py
+++ b/website_timecheck/models/res_config_settings.py
@@ -1,0 +1,12 @@
+# Copyright 2020 Quartile Limited
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
+
+from odoo import fields, models
+
+
+class ResConfigSettings(models.TransientModel):
+    _inherit = "res.config.settings"
+
+    homepage_url = fields.Char(
+        string="Homepage", related="website_id.homepage_url", readonly=False
+    )

--- a/website_timecheck/models/res_config_settings.py
+++ b/website_timecheck/models/res_config_settings.py
@@ -8,6 +8,9 @@ class ResConfigSettings(models.TransientModel):
     _inherit = "res.config.settings"
 
     homepage_url = fields.Char(
-        string="Homepage", related="website_id.homepage_url", readonly=False,
-        help="Defines the homepage for the website, leave it empty to be set as default ('/')",
+        string="Homepage",
+        related="website_id.homepage_url",
+        readonly=False,
+        help="Defines the homepage for the website, leave it empty to be set "
+        "as default ('/')",
     )

--- a/website_timecheck/models/res_config_settings.py
+++ b/website_timecheck/models/res_config_settings.py
@@ -8,5 +8,6 @@ class ResConfigSettings(models.TransientModel):
     _inherit = "res.config.settings"
 
     homepage_url = fields.Char(
-        string="Homepage", related="website_id.homepage_url", readonly=False
+        string="Homepage", related="website_id.homepage_url", readonly=False,
+        help="Defines the homepage for the website, leave it empty to be set as default ('/')",
     )

--- a/website_timecheck/models/res_users.py
+++ b/website_timecheck/models/res_users.py
@@ -1,5 +1,5 @@
 # Copyright 2020 Quartile Limited
-# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
 
 
 from odoo import api, fields, models

--- a/website_timecheck/models/sale_order.py
+++ b/website_timecheck/models/sale_order.py
@@ -1,5 +1,5 @@
 # Copyright 2020 Quartile Limited
-# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
 
 from odoo import fields, models
 

--- a/website_timecheck/models/website.py
+++ b/website_timecheck/models/website.py
@@ -11,7 +11,11 @@ from odoo.tools import DEFAULT_SERVER_DATETIME_FORMAT
 class Website(models.Model):
     _inherit = "website"
 
-    homepage_url = fields.Char(string="Homepage", help="Defines the homepage for the website, leave it empty to be set as default ('/')",)
+    homepage_url = fields.Char(
+        string="Homepage",
+        help="Defines the homepage for the website, leave it empty to be set "
+        "as default ('/')",
+    )
 
     def sale_product_domain(self):
         domain = super(Website, self).sale_product_domain()

--- a/website_timecheck/models/website.py
+++ b/website_timecheck/models/website.py
@@ -3,7 +3,7 @@
 
 import datetime
 
-from odoo import models, fields
+from odoo import fields, models
 from odoo.http import request
 from odoo.tools import DEFAULT_SERVER_DATETIME_FORMAT
 
@@ -11,9 +11,7 @@ from odoo.tools import DEFAULT_SERVER_DATETIME_FORMAT
 class Website(models.Model):
     _inherit = "website"
 
-    homepage_url = fields.Char(
-        string="Homepage",
-    )
+    homepage_url = fields.Char(string="Homepage",)
 
     def sale_product_domain(self):
         domain = super(Website, self).sale_product_domain()

--- a/website_timecheck/models/website.py
+++ b/website_timecheck/models/website.py
@@ -11,7 +11,7 @@ from odoo.tools import DEFAULT_SERVER_DATETIME_FORMAT
 class Website(models.Model):
     _inherit = "website"
 
-    homepage_url = fields.Char(string="Homepage",)
+    homepage_url = fields.Char(string="Homepage", help="Defines the homepage for the website, leave it empty to be set as default ('/')",)
 
     def sale_product_domain(self):
         domain = super(Website, self).sale_product_domain()

--- a/website_timecheck/models/website.py
+++ b/website_timecheck/models/website.py
@@ -1,15 +1,19 @@
 # Copyright 2020 Quartile Limited
-# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
 
 import datetime
 
-from odoo import models
+from odoo import models, fields
 from odoo.http import request
 from odoo.tools import DEFAULT_SERVER_DATETIME_FORMAT
 
 
 class Website(models.Model):
     _inherit = "website"
+
+    homepage_url = fields.Char(
+        string="Homepage",
+    )
 
     def sale_product_domain(self):
         domain = super(Website, self).sale_product_domain()

--- a/website_timecheck/views/res_config_settings_views.xml
+++ b/website_timecheck/views/res_config_settings_views.xml
@@ -13,7 +13,7 @@
                             string="Homepage"
                             for="homepage_url"
                         />
-                        <field name="homepage_url" widget="url"/>
+                        <field name="homepage_url" widget="url" />
                     </div>
                 </div>
             </xpath>

--- a/website_timecheck/views/res_config_settings_views.xml
+++ b/website_timecheck/views/res_config_settings_views.xml
@@ -13,7 +13,7 @@
                             string="Homepage"
                             for="homepage_url"
                         />
-                        <field name="homepage_url"/>
+                        <field name="homepage_url" />
                     </div>
                 </div>
             </xpath>

--- a/website_timecheck/views/res_config_settings_views.xml
+++ b/website_timecheck/views/res_config_settings_views.xml
@@ -13,7 +13,7 @@
                             string="Homepage"
                             for="homepage_url"
                         />
-                        <field name="homepage_url" />
+                        <field name="homepage_url" widget="url"/>
                     </div>
                 </div>
             </xpath>

--- a/website_timecheck/views/res_config_settings_views.xml
+++ b/website_timecheck/views/res_config_settings_views.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record id="res_config_settings_view_form" model="ir.ui.view">
+        <field name="name">res.config.settings.view.form.inherit.website</field>
+        <field name="model">res.config.settings</field>
+        <field name="inherit_id" ref="website.res_config_settings_view_form" />
+        <field name="arch" type="xml">
+            <xpath expr="//div[@id='domain_setting']/div" position="inside">
+                <div class="content-group">
+                    <div class="row">
+                        <label
+                            class="col-lg-3 o_light_label"
+                            string="Homepage"
+                            for="homepage_url"
+                        />
+                        <field name="homepage_url"/>
+                    </div>
+                </div>
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/website_timecheck/views/templates.xml
+++ b/website_timecheck/views/templates.xml
@@ -304,7 +304,6 @@
                 </div>
                 <div
                     t-if="product.sale_hkd_ac_so and not product.in_special_offer_limit"
-                    groups="website_timecheck.group_timecheck_trial"
                 >
                     <span style="color: red; font-weight:bold;">Special Offer:</span>
                     <t t-if="product.sale_hkd_ac_so != 0">
@@ -342,6 +341,15 @@
                     >
                         <span class="fa fa-shopping-cart" /> Checkout
                     </a>
+                    <a
+                        groups="base.group_public"
+                        href="/web/login"
+                        class="btn btn-secondary btn-sm"
+                        aria-label="Shopping cart"
+                        title="Shopping cart"
+                    >
+                        <span class="fa fa-shopping-cart" /> Checkout
+                    </a>
                 </t>
             </div>
         </xpath>
@@ -352,7 +360,6 @@
             <t
                 t-set="image_ids"
                 t-value="product.product_image_ids"
-                groups="website_timecheck.group_timecheck_light,website.group_website_publisher"
             />
         </xpath>
         <xpath expr="//h1[@itemprop='name']" position="replace">
@@ -486,7 +493,6 @@
                 </div>
                 <div
                     t-if="product.sale_hkd_ac_so and not product.in_special_offer_limit"
-                    groups="website_timecheck.group_timecheck_trial"
                 >
                     <span style="color: red; font-weight:bold;">Special Offer:</span>
                     <t t-if="product.sale_hkd_ac_so != 0">

--- a/website_timecheck/views/templates.xml
+++ b/website_timecheck/views/templates.xml
@@ -357,10 +357,7 @@
     <template id="product" name="Product" inherit_id="website_sale.product">
         <xpath expr="//t[@t-set='image_ids']" position="replace">
             <t t-set="image_ids" t-value="[]" />
-            <t
-                t-set="image_ids"
-                t-value="product.product_image_ids"
-            />
+            <t t-set="image_ids" t-value="product.product_image_ids" />
         </xpath>
         <xpath expr="//h1[@itemprop='name']" position="replace">
             <h4 itemprop="name" t-field="product.name">Product Name</h4>


### PR DESCRIPTION
Task #[907](https://www.quartile.co/web?debug=#id=907&action=771&model=project.task&view_type=form&menu_id=505)

1. Add homepage settings
2. Make the “Checkout” button available to public access, clicking it will forward the user to the login page
3. Enable searching the name of brands with the search bar
4. Show multi-images and special offer price to all groups.