### PR TITLE
[907][IMP] Add language and currency selector, adjust special offers currency

### DIFF
--- a/website_timecheck/__manifest__.py
+++ b/website_timecheck/__manifest__.py
@@ -3,7 +3,7 @@
 {
     "name": "Website Timecheck Function",
     "category": "Website",
-    "version": "12.0.1.2.0",
+    "version": "12.0.1.3.0",
     "license": "LGPL-3",
     "author": "Quartile Limited",
     "website": "https://www.quartile.co",

--- a/website_timecheck/i18n/zh_CN.po
+++ b/website_timecheck/i18n/zh_CN.po
@@ -62,6 +62,11 @@ msgid "<span>Sale HKD:</span>"
 msgstr "<span>港币卖价:</span>"
 
 #. module: website_timecheck
+#: model_terms:ir.ui.view,arch_db:website_timecheck.product
+msgid "Add to Cart"
+msgstr "加入购物车"
+
+#. module: website_timecheck
 #: model_terms:ir.ui.view,arch_db:website_timecheck.products_categories
 msgid "All Categories"
 msgstr "所有品牌"

--- a/website_timecheck/i18n/zh_TW.po
+++ b/website_timecheck/i18n/zh_TW.po
@@ -62,6 +62,11 @@ msgid "<span>Sale HKD:</span>"
 msgstr "<span>港幣賣價:</span>"
 
 #. module: website_timecheck
+#: model_terms:ir.ui.view,arch_db:website_timecheck.product
+msgid "Add to Cart"
+msgstr "加入購物車"
+
+#. module: website_timecheck
 #: model_terms:ir.ui.view,arch_db:website_timecheck.products_categories
 msgid "All Categories"
 msgstr "所有品牌"

--- a/website_timecheck/views/templates.xml
+++ b/website_timecheck/views/templates.xml
@@ -319,7 +319,10 @@
                             style="white-space: nowrap; color: red; font-weight:bold;"
                         >N/A</span>
                     </t>
-                    <span style="color: red; font-weight:bold;" t-esc="website.currency_id.name"/>
+                    <span
+                        style="color: red; font-weight:bold;"
+                        t-esc="website.currency_id.name"
+                    />
                 </div>
                 <t
                     t-set="product_variant_id"
@@ -392,7 +395,11 @@
             <attribute name="groups">website_timecheck.group_timecheck_light</attribute>
         </xpath>
         <xpath expr="//hr[@t-if='product.description_sale']" position="before">
-           <a groups="base.group_public" href="/web/login" class="btn btn-primary btn-lg mt8">Add to Cart</a>
+           <a
+                groups="base.group_public"
+                href="/web/login"
+                class="btn btn-primary btn-lg mt8"
+            >Add to Cart</a>
         </xpath>
     </template>
     <template

--- a/website_timecheck/views/templates.xml
+++ b/website_timecheck/views/templates.xml
@@ -135,7 +135,7 @@
         </xpath>
     </template>
     <template id="products" inherit_id="website_sale.products" name="Products">
-        <xpath expr="//t[@t-call='website_sale.search']" position="after">
+        <xpath expr="//t[@t-call='website_sale.search']" position="before">
             <div class="dropdown ml-2 visible-xs-inline">
                 <a
                     role="button"
@@ -309,7 +309,7 @@
                     <t t-if="product.sale_hkd_ac_so != 0">
                         <span
                             t-if="product.sale_hkd_ac_so != 0"
-                            t-esc="'{:,.0f}'.format(product.sale_hkd_ac_so)"
+                            t-esc="'{:,.0f}'.format(website.company_id.currency_id._convert(product.sale_hkd_ac_so, website.currency_id, website.company_id, datetime.date.today()))"
                             style="white-space: nowrap; color: red; font-weight:bold;"
                         />
                     </t>
@@ -319,7 +319,7 @@
                             style="white-space: nowrap; color: red; font-weight:bold;"
                         >N/A</span>
                     </t>
-                    <span style="color: red; font-weight:bold;">HKD</span>
+                    <span style="color: red; font-weight:bold;" t-esc="website.currency_id.name"/>
                 </div>
                 <t
                     t-set="product_variant_id"
@@ -390,6 +390,9 @@
         </xpath>
         <xpath expr="//form" position="attributes">
             <attribute name="groups">website_timecheck.group_timecheck_light</attribute>
+        </xpath>
+        <xpath expr="//hr[@t-if='product.description_sale']" position="before">
+           <a groups="base.group_public" href="/web/login" class="btn btn-primary btn-lg mt8">Add to Cart</a>
         </xpath>
     </template>
     <template
@@ -720,6 +723,9 @@
             <attribute name="class">hidden-xs</attribute>
         </xpath>
         <xpath expr="//li[@class='hidden-xs']" position="after">
+            <li class="visible-xs-inline">
+                <t t-call="website.language_selector" />
+            </li>
             <li
                 class="visible-xs-inline"
                 t-ignore="true"


### PR DESCRIPTION
Task #[907](https://www.quartile.co/web?debug=#id=907&action=771&model=project.task&view_type=form&menu_id=505)

3. Make the “Checkout” button available to public access in product details page, clicking it will forward the user to the login page 
1. Multi-Currency settings for websites
    Enable currency filter on website
    Transfer the “Special Offer” price (HKD) to the selected currency (including sales price)
10. Since now have new pager in the website, currently the Language selector is hard to reach, therefore put Language and Currency Settings in the top of the website site
Desktop: Currency Filter should be next to the search bar
Mobile: Language Filter should be under the Sign In area.
11. Move the "Filter" button to the left side of the search bar in the moible.