### PR TITLE
[907][IMP] Adjust pricelist selector position and style

### DIFF
--- a/website_timecheck/__manifest__.py
+++ b/website_timecheck/__manifest__.py
@@ -3,7 +3,7 @@
 {
     "name": "Website Timecheck Function",
     "category": "Website",
-    "version": "12.0.1.3.0",
+    "version": "12.0.1.3.1",
     "license": "LGPL-3",
     "author": "Quartile Limited",
     "website": "https://www.quartile.co",

--- a/website_timecheck/views/templates.xml
+++ b/website_timecheck/views/templates.xml
@@ -135,6 +135,13 @@
         </xpath>
     </template>
     <template id="products" inherit_id="website_sale.products" name="Products">
+        <xpath expr="//t[@t-call='website_sale.pricelist_list']" position="replace">
+            <div class="hidden-xs">
+                 <t t-call="website_sale.pricelist_list">
+                    <t t-set="_classes">ml-2</t>
+                </t>
+            </div>
+        </xpath>
         <xpath expr="//t[@t-call='website_sale.search']" position="before">
             <div class="dropdown ml-2 visible-xs-inline">
                 <a
@@ -358,6 +365,13 @@
         </xpath>
     </template>
     <template id="product" name="Product" inherit_id="website_sale.product">
+        <xpath expr="//t[@t-call='website_sale.pricelist_list']" position="replace">
+            <div class="hidden-xs">
+                 <t t-call="website_sale.pricelist_list">
+                    <t t-set="_classes">ml-2</t>
+                </t>
+            </div>
+        </xpath>
         <xpath expr="//t[@t-set='image_ids']" position="replace">
             <t t-set="image_ids" t-value="[]" />
             <t t-set="image_ids" t-value="product.product_image_ids" />
@@ -733,6 +747,9 @@
             <li class="visible-xs-inline">
                 <t t-call="website.language_selector" />
             </li>
+            <li class="visible-xs-inline">
+                <t t-call="website_sale.pricelist_list" />
+            </li>
             <li
                 class="visible-xs-inline"
                 t-ignore="true"
@@ -752,6 +769,16 @@
                     t-attf-href="/web/session/logout?redirect=/"
                 >Logout</a>
             </li>
+        </xpath>
+    </template>
+    <template id="pricelist_list" inherit_id="website_sale.pricelist_list" name="Pricelists Dropdown">
+        <xpath expr="//a[@role='button']" position="attributes">
+            <attribute name="class">hidden-xs dropdown-toggle btn btn-secondary</attribute>
+        </xpath>
+        <xpath expr="//a[@role='button']" position="after">
+            <a role="button" href="#" class="btn btn-sm btn-secondary dropdown-toggle visible-xs-inline" data-toggle="dropdown">
+                <t t-esc="curr_pl and curr_pl.name or ' - '" />
+            </a>
         </xpath>
     </template>
 </odoo>


### PR DESCRIPTION
Task #[907](https://www.quartile.co/web#view_type=form&model=project.task&id=907&active_id=995&menu_id=)

- Hide the pricelist selector from mobile layout.
- Add the pricelist selector under the navigation panel in the mobile layout.
![image](https://user-images.githubusercontent.com/27185427/82408075-60098100-9a9d-11ea-9867-0880d4ef68dc.png)
- Adjust the style of the pricelist button to match the language selector.
