### PR TITLE
[1047][IMP] Add _order attribute to stock.production.lot

### DIFF
--- a/stock_move_line_quant/__manifest__.py
+++ b/stock_move_line_quant/__manifest__.py
@@ -1,9 +1,9 @@
-# Copyright 2019 Quartile Limited
+# Copyright 2019-2020 Quartile Limited
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html).
 {
     "name": "Quant/Serial Number on Stock Move Line",
     "category": "Stock",
-    "version": "12.0.1.0.0",
+    "version": "12.0.1.1.0",
     "license": "LGPL-3",
     "author": "Quartile Limited",
     "website": "https://www.quartile.co",

--- a/stock_move_line_quant/models/stock_production_lot.py
+++ b/stock_move_line_quant/models/stock_production_lot.py
@@ -7,6 +7,7 @@ from odoo import api, fields, models
 
 class StockProductionLot(models.Model):
     _inherit = "stock.production.lot"
+    _order = "name ASC"
 
     currency_id = fields.Many2one(
         "res.currency", string="Purchase Currency", readonly=True


### PR DESCRIPTION
Task#[1047](https://www.quartile.co/web?debug=#id=1047&action=771&model=project.task&view_type=form&menu_id=505)

The ordering of the `stock.production.lot` as a many2one field in other models is based on the "id" of the record while `_order` attribute not being defined in the model class.
Therefore, the "Lot/Serial Number" column sorting of the stock quant tree view is in either `id` asc/desc order but not the `name` field.
