### PR TITLE
[1129][IMP] Fix empty payment's memo case

### DIFF
--- a/profit_loss_report/__manifest__.py
+++ b/profit_loss_report/__manifest__.py
@@ -2,7 +2,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 {
     "name": "Profit and Loss Report",
-    "version": "12.0.1.0.0",
+    "version": "12.0.1.0.1",
     "license": "AGPL-3",
     "author": "Quartile Limited",
     "website": "https://www.quartile.co",

--- a/profit_loss_report/wizards/profit_loss_report_wizard.py
+++ b/profit_loss_report/wizards/profit_loss_report_wizard.py
@@ -614,7 +614,10 @@ class ProfitLossReportWizard(models.TransientModel):
         return date_local.astimezone(pytz.utc).strftime("%Y-%m-%d %H:%M:%S")
 
     def _get_payment_information(self, payment_ids, net_price, invoice_id):
-        payment_reference = ", ".join(payment_ids.mapped("communication"))
+        payment_reference = ", ".join(
+            payment_ids.filtered(
+                lambda r: r.communication).mapped("communication"))
+        print(payment_reference)
         payment_currency_rate = False
         sale_base_price = False
         if len(payment_ids) == 1:

--- a/profit_loss_report/wizards/profit_loss_report_wizard.py
+++ b/profit_loss_report/wizards/profit_loss_report_wizard.py
@@ -617,7 +617,6 @@ class ProfitLossReportWizard(models.TransientModel):
         payment_reference = ", ".join(
             payment_ids.filtered(
                 lambda r: r.communication).mapped("communication"))
-        print(payment_reference)
         payment_currency_rate = False
         sale_base_price = False
         if len(payment_ids) == 1:


### PR DESCRIPTION
#[1129](https://www.quartile.co/web#id=1129&model=project.task&view_type=form&menu_id=)

When `communication` is empty, `payment_ids.mapped("communication")` will join a list with False value, .e.g `[False]` and `join()` will raise an error.