### PR TITLE
[972][IMP] Add pre-owned information fields to supplier access

### DIFF
--- a/supplier_stock_pre_owned_info/__manifest__.py
+++ b/supplier_stock_pre_owned_info/__manifest__.py
@@ -7,9 +7,7 @@
     "author": "Quartile Limited",
     "website": "https://www.quartile.co",
     "license": "LGPL-3",
-    "depends": [
-        "supplier_user_access"
-    ],
+    "depends": ["supplier_user_access"],
     "data": [
         "data/product_condition_data.xml",
         "data/product_parts_status_data.xml",

--- a/supplier_stock_pre_owned_info/__manifest__.py
+++ b/supplier_stock_pre_owned_info/__manifest__.py
@@ -1,13 +1,15 @@
 # Copyright 2020 Quartile Limited
-# License LGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html).
 {
     "name": "Pre-Owned Products Features",
-    "version": "12.0.1.0.0",
+    "version": "12.0.1.0.1",
     "category": "Stock",
     "author": "Quartile Limited",
     "website": "https://www.quartile.co",
     "license": "LGPL-3",
-    "depends": ["supplier_stock"],
+    "depends": [
+        "supplier_user_access"
+    ],
     "data": [
         "data/product_condition_data.xml",
         "data/product_parts_status_data.xml",

--- a/supplier_stock_pre_owned_info/views/supplier_stock_views.xml
+++ b/supplier_stock_pre_owned_info/views/supplier_stock_views.xml
@@ -22,4 +22,26 @@
             </xpath>
         </field>
     </record>
+    <record id="view_supplier_access_tree" model="ir.ui.view">
+        <field name="name">view.supplier.access.tree</field>
+        <field name="model">supplier.stock</field>
+        <field name="inherit_id" ref="supplier_user_access.view_supplier_access_tree" />
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='quantity']" position="after">
+                <field
+                    name="product_condition_id"
+                    options="{'no_quick_create': True, 'no_create_edit': True, 'no_open': True}"
+                />
+                <field
+                    name="product_parts_status_id"
+                    options="{'no_quick_create': True, 'no_create_edit': True, 'no_open': True}"
+                />
+                <field name="warrant_status" />
+                <field
+                    name="warranty_date"
+                    attrs="{'required':[('warrant_status','=','fix')]}"
+                />
+            </xpath>
+        </field>
+    </record>
 </odoo>


### PR DESCRIPTION
#[972](https://www.quartile.co/web?debug=#id=972&action=771&model=project.task&view_type=form&menu_id=505) 

- Add pre-owned information fields to supplier user's list view